### PR TITLE
Some re-wording and use of -1 in socket driver

### DIFF
--- a/docs/_archives/recipes/interfaces/ase/sockets/dftb_in.hsd
+++ b/docs/_archives/recipes/interfaces/ase/sockets/dftb_in.hsd
@@ -1,7 +1,7 @@
 Driver = Socket {
   File = "dftbplus"
   Protocol = i-PI {}
-  MaxSteps = 1000
+  MaxSteps = -1
   Verbosity = 0
 }
 
@@ -23,4 +23,3 @@ Hamiltonian = DFTB {
     Suffix = ".skf"
   }
 }
-

--- a/docs/_archives/recipes/interfaces/ase/sockets/dftb_in.hsd
+++ b/docs/_archives/recipes/interfaces/ase/sockets/dftb_in.hsd
@@ -1,7 +1,7 @@
 Driver = Socket {
   File = "dftbplus"
   Protocol = i-PI {}
-  MaxSteps = -1
+  MaxSteps = 1000
   Verbosity = 0
 }
 

--- a/docs/interfaces/ase/fileio/fileio.rst
+++ b/docs/interfaces/ase/fileio/fileio.rst
@@ -4,24 +4,25 @@
 File-IO
 *******
 
-For calculations without heavy file-IO, i.e. systems whose wallclock time is 
-dominated by the diagonalizations due to extensive SCC cycles, the 
-communication between DFTB+ and external software via file-IO may be suitable.
+For calculations without heavy file-IO, i.e. systems whose wallclock time is
+dominated by the electronic structure part of the calculation (due to extensive
+SCC cycles or large system size), the communication between DFTB+ and external
+software via file-IO may be suitable.
 
 Calling DFTB+ via ASE
 =====================
 
 [Input: `recipes/interfaces/ase/fileio/1_conjgrad/`]
 
-In order for ASE to find the DFTB+ executable and Slater-Koster files, 
-environment variables must be set. Assuming the use of BASH, this is done as 
-follows (in general an adaptation to the individual system is
-necessary)::
+In order for ASE to find the DFTB+ executable and Slater-Koster files,
+environment variables must be set. Assuming the use of the BASH shell, this is
+done as follows (in general an adaptation to your specific computing environment
+will be necessary)::
 
     $ DFTB_PREFIX=~/slakos/mio-0-1/
     $ DFTB_COMMAND=~/dftbplus/bin/dftb+
 
-In this case the geometry optimization of a simple water molecule serves as an 
+In this case the geometry optimization of a simple water molecule serves as an
 example::
 
     3  C
@@ -30,12 +31,12 @@ example::
          2    2    0.00000000000E+00   0.00000000000E+00   0.78306400000E+00
          3    2    0.00000000000E+00   0.00000000000E+00  -0.78306400000E+00
 
-Following the necessary imports, the main script defines the path to the DFTB+ 
-executable and the geometry .gen file containing the water molecule shown above. 
-The main method then first reads in the geometry. Subsequently, a ``DFTB()`` 
-calculator object with options that are crucial for the actual calculation 
-is instantiated. Here we perform a self-consistent calculation with 
-``ConjugateGradient{}`` as the driver.
+Following the necessary imports, the main script defines the path to the DFTB+
+executable and the geometry .gen file containing the water molecule shown above.
+The main method then first reads in the geometry. Subsequently, a ``DFTB()``
+calculator object with options that are crucial for the actual calculation is
+then instantiated. Here we perform a self-consistent calculation with the DFTB+
+``ConjugateGradient{}`` method as the driver.
 
 The calculator gets attached to the system or geometry respectively and the 
 calculation is started.
@@ -76,7 +77,7 @@ of the system can be read out directly by ASE:
     if __name__ == "__main__":
         main()
 
-The script shown causes ASE to create an input file (`dftb_in.hsd`) with the 
+The script above causes ASE to create an input file (`dftb_in.hsd`) with the
 specified options and invokes DFTB+ in the corresponding directory.
 
 Geometry Optimization by ASE
@@ -130,9 +131,10 @@ calculators provided by ASE:
     if __name__ == "__main__":
         main()
 
-The script shown causes ASE to generate appropriate input files for each step 
-of the geometry optimization. Note that this can lead to heavy file-IO and 
-thus a significant increase in wallclock time, depending on the speed of 
-the storage used. Therefore it is advisable to perform such calculations on a 
-ramdisk or even better via :ref:`sec-sockets`.
-
+The script shown causes ASE to generate appropriate input files for each step of
+the geometry optimization. Note that this can lead to heavy file-IO and thus a
+significant increase in wallclock time, depending on the speed of the storage
+used. Additionally, the self-consistency is started from fresh for each
+structure, substantially increasing the number of SCC cycles. Therefore it is
+advisable to perform such calculations on a ramdisk or even better via
+:ref:`sec-sockets`.

--- a/docs/interfaces/ase/index.rst
+++ b/docs/interfaces/ase/index.rst
@@ -9,8 +9,8 @@ modules for setting up, manipulating, running, visualizing and analyzing
 atomistic simulations (cf. `ASE documentation 
 <https://wiki.fysik.dtu.dk/ase/>`_). 
 
-Thanks to mutual support of socket-communication and file-IO by ASE and DFTB+, 
-you can freely choose the most suitable communication type for you. Further 
+Thanks to mutual support of socket-communication and file-IO by ASE and DFTB+,
+you can freely choose the most suitable type of communication for you. Further
 information can be found in the sections linked below.
 
 Note: Before going through the following sections, please make sure that you have 

--- a/docs/interfaces/ase/sockets/sockets.rst
+++ b/docs/interfaces/ase/sockets/sockets.rst
@@ -39,10 +39,11 @@ appropriate ``Socket{}`` driver option::
 
 Which instructs DFTB+ to read geometry driving commands via a named temporary
 communication file (stored in /tmp/). In this example, due to a bug in the
-current ASE implementation of the i-PI protocol, the code performs up to 1000
-geometry steps under control of the external interface then stops. For external
-driving codes that support the `EXIT` command in the protocol, instead DFTB+ can
-continue running until told to stop by using::
+current ASE implementation of the i-PI protocol (see note below), the code is
+asked to perform up to 1000 geometry steps under control of the external
+interface then stop. For external driving codes that support the `EXIT` command
+in the protocol, instead DFTB+ can continue running until told to stop by
+using::
 
   MaxSteps = -1
 

--- a/docs/interfaces/ase/sockets/sockets.rst
+++ b/docs/interfaces/ase/sockets/sockets.rst
@@ -33,9 +33,18 @@ appropriate ``Socket{}`` driver option::
     Driver = Socket {
       File = "dftbplus"
       Protocol = i-PI {}
-      MaxSteps = -1 # continues until externally stopped
+      MaxSteps = 1000
       Verbosity = 0
     }
+
+Which instructs DFTB+ to read geometry driving commands via a named temporary
+communication file (stored in /tmp/). In this example, due to a bug in the
+current ASE implementation of the i-PI protocol, the code performs up to 1000
+geometry steps under control of the external interface then stops. For external
+driving codes that support the `EXIT` command in the protocol, instead DFTB+ can
+continue running until told to stop by using::
+
+  MaxSteps = -1
 
 Due to the nature of the i-PI protocol, a dummy geometry must be provided, from
 which the number and species of the atoms, as well as unit cell vectors will be

--- a/docs/interfaces/ase/sockets/sockets.rst
+++ b/docs/interfaces/ase/sockets/sockets.rst
@@ -7,19 +7,18 @@ Socket-Communication
 
 [Input: `recipes/interfaces/ase/sockets/`]
 
-For calculations that heavily rely on file-IO, reference to the possibility of 
-communication between DFTB+ and ASE, based on the i-PI protocol, 
-should be made. In these cases, the reduction of the wallclock time can be 
-significant.
+For calculations that heavily rely on file-IO, it is better to use communication
+between DFTB+ and ASE with the i-PI protocol. In these cases, the reduction of
+the wallclock time can be significant.
 
-Note: At this time, only the communication with ASE has been experimentally 
-verified. In general, however, communication with software using the i-PI 
-protocol should be supported.
+Note: At this time, only communication with ASE or i-PI has been tested. In
+general, however, other software which correctly implements the i-PI protocol
+should be supported.
 
 .. note::
 
-    To enable socket-communication in DFTB+ the `WITH_SOCKETS` flag in the 
-    configuration file `config.cmake` must be set to TRUE, before starting the 
+    To enable socket-communication in DFTB+ the `WITH_SOCKETS` flag in the
+    configuration file `config.cmake` must be set to TRUE, before starting the
     compilation process!
 
 Geometry Optimization by ASE
@@ -28,32 +27,32 @@ Geometry Optimization by ASE
 Providing the input for DFTB+
 -----------------------------
 
-To establish a connection via socket communication, DFTB+ is called with the 
+To establish a connection via socket communication, DFTB+ is called with the
 appropriate ``Socket{}`` driver option::
 
     Driver = Socket {
       File = "dftbplus"
       Protocol = i-PI {}
-      MaxSteps = 1000
+      MaxSteps = -1 # continues until externally stopped
       Verbosity = 0
     }
 
-Due to the limited nature of the i-PI protocol, a dummy geometry must be 
-provided, from which the number and species of the atoms, as well as the cell 
-vectors will be read. In general, the specification of arbitrary positions and 
-cell vectors is possible. However, to avoid errors due to a different order of 
-atoms in the ASE-geometry and the species in the dummy-geometry, this 
-example uses the ability of ASE to read in and write out .gen files. The output 
-geometry (`geo.gen`) is then used as input for DFTB+, avoiding the possible 
-mentioned errors::
+Due to the nature of the i-PI protocol, a dummy geometry must be provided, from
+which the number and species of the atoms, as well as unit cell vectors will be
+read. In general, the specification of arbitrary positions and cell vectors is
+possible. However, to avoid errors due to a different ordering of the atoms in
+the ASE-geometry and the species in the dummy-geometry, this example uses the
+ability of ASE to read in and write out .gen files. The output geometry
+(`geo.gen`) is then used as input for DFTB+, avoiding the possibility of the
+above mentioned errors::
 
     Geometry = GenFormat {
       <<< "geo.gen"
     }
 
-The calculation of a water molecule is performed without self-consistency cycles 
-and the required Slater-Koster files in the top-level directory (same folder as 
-`dftb_in.hsd`)::
+In this example, calculation of a water molecule is performed without charge
+self-consistency and the required Slater-Koster files are stored in the
+top-level directory (same folder as `dftb_in.hsd`)::
 
     Hamiltonian = DFTB {
       SCC = No
@@ -70,12 +69,12 @@ and the required Slater-Koster files in the top-level directory (same folder as
       }
     }
 
-For the full input file assembled from the code snippets shown here, please 
-consult the archive, whose location is stated at the begin of the section.
+For the full input file assembled from the code snippets shown here, please
+consult the archive, whose location is stated at the begin of this section.
 
 Geometry and main script
 ------------------------
-The geometry used is a simple water molecule, whose location is specified in the 
+The geometry used is a simple water molecule, whose file location is specified in the
 main script (`GEO_PATH`)::
 
     3  C
@@ -84,14 +83,14 @@ main script (`GEO_PATH`)::
          2    2    0.00000000000E+00   0.00000000000E+00   0.78306400000E+00
          3    2    0.00000000000E+00   0.00000000000E+00  -0.78306400000E+00
 
-Following the necessary imports, the main script defines the type of socket to 
+Following the necessary imports, the main script defines the type of socket to
 be used (UNIX socket) as well as the path to the DFTB+ executable (`DFTBP_PATH`)
-and the geometry (`GEO_PATH`). The main method then first reads in the geometry 
-and immediately writes it out for the reasons mentioned above. Subsequently, 
-the driver ``BFGS()`` of the geometry optimization is specified and where to 
+and the geometry (`GEO_PATH`). The main method then first reads in the geometry
+and immediately writes it out for the reasons mentioned above. Subsequently,
+the ASE driver ``BFGS()`` for geometry optimization is specified and where to
 write the trajectory and the logfile.
 
-Finally, the convergent forces and the corresponding energy of the system can 
+Finally, the convergent forces and the corresponding energy of the system can
 be read out directly by ASE:
 
 .. code-block:: python
@@ -128,10 +127,9 @@ be read out directly by ASE:
 
 .. note::
 
-    To correctly close sockets on the ASE side, call `calc.close()` at the end 
-    or, more elegantly, enclose the class ``SocketIOCalculator`` using the 
-    `with` statement as done in the example shown here. Nevertheless, in the 
-    current state of ASE, the socket gets closed without warning missing the 
-    'EXIT' string of the i-PI protocol, which always leads to an error message 
+    To correctly close sockets on the ASE side, call `calc.close()` at the end
+    or, more elegantly, enclose the class ``SocketIOCalculator`` using the
+    `with` statement as done in the example shown here. Nevertheless, in the
+    current state of ASE, the socket gets closed without warning missing the
+    'EXIT' string of the i-PI protocol, which always leads to an error message
     issued by DFTB+ at the end of a calculation driven by socket-communication.
-

--- a/docs/interfaces/index.rst
+++ b/docs/interfaces/index.rst
@@ -4,10 +4,10 @@
 Interfaces
 ##########
 
-In this section the possibility of communication between DFTB+ and external
-software is shown. This improves the ease of use and enables the user to 
-invoke DFTB+ via known software, such as the Atomic Simulation Environment - 
-ASE.
+In this section the methods for communication between DFTB+ and external
+software is shown. This improves the ease of use and enables the user to invoke
+DFTB+ via software they are more familiar with, such as the Atomic Simulation
+Environment - ASE.
 
 Furthermore, the interface communication offers the possibility of 
 expanding the applications and functionality of DFTB+. For example, DFTB+ can 

--- a/docs/interfaces/index.rst
+++ b/docs/interfaces/index.rst
@@ -1,8 +1,8 @@
 .. _sec-interfaces:
 
-##########
-Interfaces
-##########
+###########################
+Interfaces with other codes
+###########################
 
 In this section the methods for communication between DFTB+ and external
 software is shown. This improves the ease of use and enables the user to invoke


### PR DESCRIPTION
Please test the changed socket driver example (the -1 option keeps the DFTB+ instance live until externally stopped, instead of a pre-specified number of iterations).